### PR TITLE
3.0.1

### DIFF
--- a/components/DesktopMenu.js
+++ b/components/DesktopMenu.js
@@ -1,7 +1,7 @@
 import Link from 'next/link'
 import { t } from '../polyglot-modules/polyglot.js'
 
-const primaryLinks = [0, 1, 2, 3, 4, 5]
+const primaryLinks = [0, 1, 2, 3, 4, 5, 6]
 const secondaryLinks = [0, 1, 2, 3]
 
 const DesktopMenu = (props) => (

--- a/components/FooterNavbar.js
+++ b/components/FooterNavbar.js
@@ -3,7 +3,7 @@ import Router from 'next/router'
 import jump from 'jump.js'
 import { t } from '../polyglot-modules/polyglot.js'
 
-const primaryLinks = [0, 1, 2, 3, 4, 5]
+const primaryLinks = [0, 1, 2, 3, 4, 5, 6]
 const secondaryLinks = [0, 1, 2, 3]
 
 

--- a/components/MobileMenu.js
+++ b/components/MobileMenu.js
@@ -1,7 +1,7 @@
 import Link from 'next/link'
 import { t } from '../polyglot-modules/polyglot.js'
 
-const primaryLinks = [0, 1, 2, 3, 4, 5]
+const primaryLinks = [0, 1, 2, 3, 4, 5, 6]
 const secondaryLinks = [0, 1, 2, 3]
 
 const MobileMenu = (props) => (

--- a/package-lock.json
+++ b/package-lock.json
@@ -2676,11 +2676,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2693,15 +2695,18 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2804,7 +2809,8 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2814,6 +2820,7 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2826,17 +2833,20 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -2853,6 +2863,7 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2925,7 +2936,8 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2935,6 +2947,7 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3040,6 +3053,7 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",

--- a/pages/index.js
+++ b/pages/index.js
@@ -79,8 +79,8 @@ export default class extends Component {
           <Collaborate />
           <Publications />
           <Ebooks />
-          <Media />
           <Content />
+          <Media />
           <WhoWeAre />
           <Footer />
         </Layout>

--- a/sections/about/containers/Content.js
+++ b/sections/about/containers/Content.js
@@ -7,12 +7,11 @@ class Content extends React.Component{
     super(props)
     this.playlistId = 'PL-5jaKJlVw83pDzsOkK079BTOzrZ-VfNT'
     this.state = {
-      currentVideo : 'qJn3XVme-oQ',
+      currentVideo : 'yTMVjoovdh8',
       videos: null
     }
   }
   
-    
   handleClick = (id) => () => {
     this.setState({ currentVideo : id })
   }

--- a/sections/index/components/ProfileCard.js
+++ b/sections/index/components/ProfileCard.js
@@ -9,18 +9,18 @@ const ProfileCard = ( {name, bio, handle, img, url} ) => (
   <style jsx>{`
     .profile-card {
       align-items: space-between;
-      background-image: url(${img});
       background-size: cover;
       background-repeat: no-repeat;
       background-position: center;
       border-radius: 100%;
       display: flex;
       flex-wrap: wrap;
-      height: 250px;
       justify-content: center;
       position: relative;
-      width: 20%;
+      height: 250px;
+      width: 250px;
       margin-bottom:30px;
+      background-image: url(${img});
     }
     .profile-card-container {
       display: none;
@@ -144,14 +144,14 @@ const ProfileCard = ( {name, bio, handle, img, url} ) => (
         margin-right: 10px;
       }
     }
-    @media screen and (min-width: 1200px) {
+   /*  @media screen and (min-width: 1200px) {
       .profile-card:nth-child(13) {
         margin-left: 25%
       }
       .profile-card:nth-child(14) {
         margin-right: 25%
       }
-    }
+    } */
     @media screen and (min-width: 1024px) {
       .profile-card:hover .profile-card-container {
         heigth:260px;

--- a/sections/index/containers/Collaborate.js
+++ b/sections/index/containers/Collaborate.js
@@ -70,7 +70,7 @@ class Collaborate extends Component {
             display: flex;
             flex-direction: column;
             align-items: center;
-            width: 486px;
+            width: 387px;
           }
           .collaborate-container .section-title {
             align-self: center;
@@ -104,7 +104,7 @@ class Collaborate extends Component {
               padding-bottom: 48px;
             }
             .collaborate-container {
-              width: 100%;
+              width: 80%;
             }
             .flickity-prev-next-button.previous{
               margin-left: -35px;

--- a/sections/index/containers/WhoWeAre.js
+++ b/sections/index/containers/WhoWeAre.js
@@ -28,7 +28,8 @@ class WhoWeAre extends Component {
       const options = {
         cellCelector: '.profile-card',
         cellAlign: 'center',
-        pageDots: false,
+        pageDots: true,
+        prevNextButtons: false,
         wrapAround: wrapAround
       }
       this.flickity = new Flickity(this.refs.carousel, options)
@@ -51,11 +52,9 @@ class WhoWeAre extends Component {
           }
           .profile-container {
             display: flex;
-            flex-flow: row wrap;
-            justify-content: space-around;
-            height: auto;
+            flex-wrap: wrap;
+            justify-content: center;
             margin-top: 72px;
-            width: 100%;
           }
           @media screen and (min-width: 1440px) {
             .who-we-are-section {
@@ -74,8 +73,7 @@ class WhoWeAre extends Component {
             .profile-container {
               display: block;
               margin-top: 33px;
-              height: 250px;
-              overflow: hidden;
+              height: 265px;    
             }
             .flickity-prev-next-button {
               width: 100px;

--- a/sections/transparency/component/DetailOutcome.js
+++ b/sections/transparency/component/DetailOutcome.js
@@ -50,6 +50,8 @@ class DetailOutcome extends Component {
     }
     render() {
       const chartOptions = {
+        maintainAspectRatio: false,
+        responsive: true,
         scales: {
           yAxes: [
             {
@@ -78,27 +80,49 @@ class DetailOutcome extends Component {
                     <div className="detailOutcome-graphic">
                     <Bar
                       data={data}
-                     width={650}
-                     height={350}
+                      width={650}
+                      height={300}
                      options={chartOptions}
                     />
                     </div>
-                       <style jsx>{
-                         `
-                         
-                         .subtitle {
-                           text-align: center;
-                         }
-                         
-                         @media (max-width: 700px) {
-                           
+                       <style jsx>{`
+                         .detailOutcome-container{
+                          min-width: 0
+                        }
+                       .detailOutcome-graphic {
+                          position: relative;
+                         /*  height: 70vh;
+                          width: 40vw; */
+                          margin-right: 25px;
+                          min-width: 0
+                       }
+                        .subtitle {
+                          text-align: center;
+                        }
+    
+                        @media (min-width: 780px) and (max-width: 1400px) {
                           .detailOutcome-container {
-                            margin-top: 20px;
-                           }
-
-                           .detailOutcome-graphic {
-                            margin-top: 10px;
+                            margin-bottom: 20px;
                           }
+    
+                          
+                        .detailOutcome-graphic {
+                          margin: 0 0 20px 0;
+                           height: 60vh;
+                          width: 65vw; 
+                        }
+                        }
+                        @media (min-width: 341px) and (max-width: 780px) {
+                          .detailOutcome-container {
+                            margin-bottom: 20px;
+                          }
+    
+                          
+                        .detailOutcome-graphic {
+                          margin: 0 0 10px 0;
+                           height: 36vh;
+                          width: 85vw; 
+                        }
                          }
 
                          `

--- a/sections/transparency/component/DetailOutcome.js
+++ b/sections/transparency/component/DetailOutcome.js
@@ -49,35 +49,60 @@ class DetailOutcome extends Component {
         }
     }
     render() {
+      const chartOptions = {
+        scales: {
+          yAxes: [
+            {
+              ticks: {
+                callback: function(value) {
+                  return '$' + value.toFixed(0).toString().replace(/\B(?=(\d{3})+(?!\d))/g, ".")
+              }
+                }
+            }
+          ]
+      },
+        tooltips: {
+          callbacks: {
+            label: function (tooltipItem, data) {
+              var tooltipValue = data.datasets[tooltipItem.datasetIndex].data[tooltipItem.index];
+              return '$' + parseInt(tooltipValue).toFixed(0).toString().replace(/\B(?=(\d{3})+(?!\d))/g, ".");
+            }
+          }
+        }
+      }
         const {data} = this.state;
         const {subtitle} = this.props;
         return (
-            <div>
+            <div className="detailOutcome-container">
                  <div className="subtitle">{subtitle}</div>
+                    <div className="detailOutcome-graphic">
                     <Bar
                       data={data}
                      width={650}
                      height={350}
-                     options={{scales: {
-                      yAxes: [
-                        {
-                            ticks: {
-                               callback: function(label) {
-                                 return '$' + label;
-                               }
-                            }
-                        }
-                      ]
-                  }}}
-                
-                      
+                     options={chartOptions}
                     />
+                    </div>
                        <style jsx>{
                          `
+                         
                          .subtitle {
                            text-align: center;
                          }
+                         
+                         @media (max-width: 700px) {
+                           
+                          .detailOutcome-container {
+                            margin-top: 20px;
+                           }
+
+                           .detailOutcome-graphic {
+                            margin-top: 10px;
+                          }
+                         }
+
                          `
+
                        }
                        </style>
                   </div>

--- a/sections/transparency/component/Details.js
+++ b/sections/transparency/component/Details.js
@@ -1,5 +1,6 @@
 import React, {Component} from 'react';
-import {Bar} from 'react-chartjs-2';
+import {Bar, defaults} from 'react-chartjs-2';
+
 
 class Details extends Component {
     constructor(props) {
@@ -31,34 +32,60 @@ class Details extends Component {
         }
     }
     render() {
+        const chartOptions = {
+          scales: {
+            yAxes: [
+              {
+                ticks: {
+                  callback: function(value) {
+                    return '$' + value.toFixed(0).toString().replace(/\B(?=(\d{3})+(?!\d))/g, ".")
+                }
+                  }
+              }
+            ]
+        },
+          tooltips: {
+            callbacks: {
+              label: function (tooltipItem, data) {
+                var tooltipValue = data.datasets[tooltipItem.datasetIndex].data[tooltipItem.index];
+                return '$' + parseInt(tooltipValue).toFixed(0).toString().replace(/\B(?=(\d{3})+(?!\d))/g, ".");
+              }
+            }
+          }
+
+        }
         const {data} = this.state;
         const {subtitle} = this.props;
         return (
-            <div>
+            <div className="details-container">
               <div className="subtitle">{subtitle}</div>
+              <div className="details-graphic">
                     <Bar
                       data={data}
                      width={650}
                      height={350}
-                     options={{scales: {
-                      yAxes: [
-                        {
-                            ticks: {
-                               callback: function(label) {
-                                 return '$' + label;
-                               }
-                            }
-                        }
-                      ]
-                  }}}
+                     options={chartOptions}
                    
                       
                     />
+                    </div>
                     <style jsx>
                     
-                    {`.subtitle {
+                    {`
+                    .subtitle {
                       text-align: center;
-                    }`}
+                    }
+                    @media (max-width: 700px) {
+                      .details-container {
+                        margin-bottom: 20px;
+                      }
+
+                      
+                    .details-graphic {
+                      margin-bottom: 15px;
+                    }
+                     }
+                    `}
 
                     </style>
                   </div>

--- a/sections/transparency/component/Details.js
+++ b/sections/transparency/component/Details.js
@@ -33,6 +33,8 @@ class Details extends Component {
     }
     render() {
         const chartOptions = {
+        maintainAspectRatio: false,
+        responsive: true,
           scales: {
             yAxes: [
               {
@@ -62,8 +64,8 @@ class Details extends Component {
               <div className="details-graphic">
                     <Bar
                       data={data}
-                     width={650}
-                     height={350}
+                      width={650}
+                     height={300}
                      options={chartOptions}
                    
                       
@@ -72,19 +74,46 @@ class Details extends Component {
                     <style jsx>
                     
                     {`
+                    .details-container {
+                      min-width: 0
+                    }
+                   .details-graphic {
+                      position: relative;
+                     /*  height: 70vh;
+                      width: 40vw; */
+                      margin-right: 25px;
+                      min-width: 0
+                   }
                     .subtitle {
                       text-align: center;
                     }
-                    @media (max-width: 700px) {
+
+                    @media (min-width: 780px) and (max-width: 1400px) {
                       .details-container {
                         margin-bottom: 20px;
                       }
 
                       
                     .details-graphic {
-                      margin-bottom: 15px;
+                      margin: 0 0 20px 0;
+                       height: 60vh;
+                      width: 65vw; 
+                    }
+                    }
+                    @media (min-width: 341px) and (max-width: 780px) {
+                      .details-container {
+                        margin-bottom: 5px;
+                      }
+
+                      
+                    .details-graphic {
+                      margin: 0 0 5px 0;
+                       height: 40vh;
+                      width: 85vw; 
                     }
                      }
+
+                    
                     `}
 
                     </style>

--- a/sections/transparency/component/Expenses.js
+++ b/sections/transparency/component/Expenses.js
@@ -33,15 +33,20 @@ class Expenses extends Component {
             }]
             
 
-            }
+            },
+            
         }
-    }
+    } 
+
+     
+
+
 
     render() {
         const {data} = this.state;
         const {subtitle} = this.props;
-        
         const option = {
+          cutoutPercentage: 65,
           maintainAspectRatio: false,
           responsive: true,
           tooltips: {
@@ -61,12 +66,15 @@ class Expenses extends Component {
           }
         }
         return (
+   
             <div className="expenses-container">
-           <div className="title"><span>{subtitle}</span></div>
-           <div className="expenses-graphic">
+           <div className="subtitle">{subtitle}</div>
+           <div className="expenses-graphic" ref={ (divElement) => this.divElement = divElement}>
             <Doughnut
             data={data}
-            options={option}
+            options={option} 
+            width={650}
+            height={500}
              />
              </div>
             <style jsx>
@@ -78,23 +86,38 @@ class Expenses extends Component {
         overflow-x: hidden;
         flex-wrap: wrap;
         }
-        .title{
+        .subtitle{
             margin-top: 10px;
             margin-bottom: 10px;
             text-align: center;
             width: 100%;
-        }
-        .title span {
-            font-weight: 600;
             font-size: 35px;
         }
+       
         .expenses-graphic {
           display: flex;
           justify-content: center;
           height: 50vh;
-         
+          min-width: 0;
           position: relative;
         }
+        canvas {
+          width: 360px;
+        }
+
+        @media (min-width: 780px) and (max-width: 1400px) {
+          .expenses-graphic {
+            height: 60vh;
+            width: 65vw; 
+          }
+      }
+      @media (min-width: 341px) and (max-width: 780px) {
+        .expenses-graphic {
+          height: 40vh;
+          width: 85vw; 
+        }
+      }
+
 
   `}
 

--- a/sections/transparency/component/Expenses.js
+++ b/sections/transparency/component/Expenses.js
@@ -42,6 +42,8 @@ class Expenses extends Component {
         const {subtitle} = this.props;
         
         const option = {
+          maintainAspectRatio: false,
+          responsive: true,
           tooltips: {
             callbacks: {
               label: function(tooltipItem, data) {
@@ -61,12 +63,12 @@ class Expenses extends Component {
         return (
             <div className="expenses-container">
            <div className="title"><span>{subtitle}</span></div>
+           <div className="expenses-graphic">
             <Doughnut
-            width={350}
-            height={250}
             data={data}
             options={option}
              />
+             </div>
             <style jsx>
                     {`
         .expenses-container{
@@ -85,6 +87,13 @@ class Expenses extends Component {
         .title span {
             font-weight: 600;
             font-size: 35px;
+        }
+        .expenses-graphic {
+          display: flex;
+          justify-content: center;
+          height: 50vh;
+         
+          position: relative;
         }
 
   `}

--- a/sections/transparency/component/Income.js
+++ b/sections/transparency/component/Income.js
@@ -63,7 +63,9 @@ class Income extends Component {
     render() {
         const {data} = this.state;
         const {subtitle} = this.props;
-        const option = {
+        const chartOptions = {
+          maintainAspectRatio: false,
+          responsive: true,
           tooltips: {
             callbacks: {
               label: function(tooltipItem, data) {
@@ -82,12 +84,13 @@ class Income extends Component {
         return (
             <div className="income-container">
            <div className="title"><span>{subtitle}</span></div>
+           <div className="income-graphic">
             <Doughnut
-            width={180}
-            height={180}
             data={data}
-            options={option}
+            options={chartOptions}
+            
              />
+             </div>
             <style jsx>
                     {`
         .income-container{
@@ -108,6 +111,14 @@ class Income extends Component {
             font-size: 35px;
 
         }
+        .income-graphic {
+          display: flex;
+          justify-content: center;
+          height: 50vh;
+         
+          position: relative;
+        }
+       
 
   `}
 

--- a/sections/transparency/component/Income.js
+++ b/sections/transparency/component/Income.js
@@ -83,12 +83,13 @@ class Income extends Component {
         }
         return (
             <div className="income-container">
-           <div className="title"><span>{subtitle}</span></div>
+           <div className="subtitle">{subtitle}</div>
            <div className="income-graphic">
             <Doughnut
             data={data}
             options={chartOptions}
-            
+            width={650}
+            height={150}
              />
              </div>
             <style jsx>
@@ -99,26 +100,36 @@ class Income extends Component {
         align-items: center;
         overflow-x: hidden;
         flex-wrap: wrap;
+        min-width: 0;
         }
-        .title{
+        .subtitle{
             margin-top: 10px;
             margin-bottom: 10px;
             text-align: center;
             width: 100%;
-        }
-        .title span {
-            font-weight: 600;
             font-size: 35px;
-
         }
+        
         .income-graphic {
           display: flex;
           justify-content: center;
-          height: 50vh;
-         
+          height: 45vh;
+          min-width: 0;
           position: relative;
         }
-       
+
+        @media (min-width: 780px) and (max-width: 1400px) {
+            .income-graphic {
+              height: 60vh;
+              width: 65vw; 
+            }
+        }
+        @media (min-width: 341px) and (max-width: 780px) {
+          .income-graphic {
+            height: 40vh;
+            width: 85vw; 
+          }
+        }
 
   `}
 

--- a/sections/transparency/component/Parity.js
+++ b/sections/transparency/component/Parity.js
@@ -34,6 +34,8 @@ class Parity extends Component {
 render() {
 
   const chartOptions = {
+    maintainAspectRatio: false,
+    responsive: true,
     legend: {
       labels: {
         fontFamily: "Dosis-Regular, 'Roboto', 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -75,16 +77,38 @@ render() {
       <div className="parity-subtitle">
         <h1>{subtitle}</h1>
         </div>
+        <div className="parity-graphic">
       <HorizontalBar
-       width={650}
-       data={data} 
+       width={600}
        height={450}
+       data={data} 
        options={chartOptions}
        />
+       </div>
      <style jsx>{`
        .parity-subtitle {
          margin: 15px;
          text-align: center;
+       }
+       .parity-graphic {
+         min-width: 0;
+         display: flex;
+         justify-content: center;
+         align-items: center;
+       }
+
+       @media (min-width: 300px) and (max-width: 780px) {
+         .parity-graphic {
+           height: 40vh;
+           width: 85vw; 
+         }
+       }
+
+       @media (min-width: 780px) and (max-width: 1400px) {
+        .parity-graphic {
+          height: 40vh;
+          width: 85vw; 
+        }
        }
      `}
      

--- a/sections/transparency/component/Parity.js
+++ b/sections/transparency/component/Parity.js
@@ -32,6 +32,42 @@ class Parity extends Component {
     }
   }
 render() {
+
+  const chartOptions = {
+    legend: {
+      labels: {
+        fontFamily: "Dosis-Regular, 'Roboto', 'Helvetica Neue', Helvetica, Arial, sans-serif",
+        fontSize: 20
+      }
+    },
+    scales:
+        {
+          xAxes:[{display: false}],
+          yAxes:[
+            {
+              gridLines: {display: false},
+             ticks: {
+               fontSize: 20,
+               fontFamily: "Dosis-Regular, 'Roboto', 'Helvetica Neue', Helvetica, Arial, sans-serif"
+              }            
+           }
+           ]
+        },
+        tooltips: {
+          callbacks: {
+            label: function(tooltipItem, data) {
+                //get de current data set
+                let title = data.datasets[tooltipItem.datasetIndex].label;
+              let dataset = data.datasets[tooltipItem.datasetIndex];
+              //get the current items value
+              let currentValue = dataset.data[tooltipItem.index];
+             return title + ': ' + currentValue + '%';
+            },
+           
+          }
+        }
+
+  }
   const {data} = this.state
   const {subtitle} = this.props
   return (
@@ -43,19 +79,7 @@ render() {
        width={650}
        data={data} 
        height={450}
-       options={{
-        scales:
-        {
-          xAxes:[{display: false}],
-          yAxes:[
-            {
-              gridLines: {display: false},
-             ticks: {fontSize: 20}            
-           }
-           ]
-        }
-        }
-      }
+       options={chartOptions}
        />
      <style jsx>{`
        .parity-subtitle {

--- a/sections/transparency/containers/BalanceSheet.js
+++ b/sections/transparency/containers/BalanceSheet.js
@@ -34,6 +34,7 @@ const BalanceSheet = (props) => {
       justify-content: center;
       width: 100%;
     }
+   
     `}
     </style>
     </section>

--- a/sections/transparency/containers/Content.js
+++ b/sections/transparency/containers/Content.js
@@ -5,7 +5,7 @@ const Content = (props) => (
     <div>
       <img src={props.icon}/>
     </div>
-    <h2 className='section-title'>{t('transparency.title')}</h2>
+    <div className='title'><h1>{t('transparency.title')}</h1></div>
     <div className="section-subtitle">
       <p>{t('transparency.subtitle')}</p>
       <div className="section-text">

--- a/sections/transparency/containers/DoughnutGraphic.js
+++ b/sections/transparency/containers/DoughnutGraphic.js
@@ -17,8 +17,20 @@ class DoughnutGraphic extends Component{
       <style jsx>{`
     .graphic-section {
       display: flex;
+      justify-content: space-around;
+      overflow-x: hidden;
+      height: auto;
+      
+    }
+    @media (max-width: 700px) {
+      .graphic-section {
+        display: flex;
+      flex-flow: column wrap;
       justify-content: center;
       overflow-x: hidden;
+
+      }
+      
     }
 
   `}</style>

--- a/sections/transparency/containers/DoughnutGraphic.js
+++ b/sections/transparency/containers/DoughnutGraphic.js
@@ -22,12 +22,14 @@ class DoughnutGraphic extends Component{
       height: auto;
       
     }
-    @media (max-width: 700px) {
+
+    @media (min-width: 300px) and (max-width: 780px) {
       .graphic-section {
+
         display: flex;
-      flex-flow: column wrap;
-      justify-content: center;
-      overflow-x: hidden;
+        flex-flow: column wrap;
+        justify-content: center;
+        overflow-x: hidden;
 
       }
       

--- a/sections/transparency/containers/HorizontalBars.js
+++ b/sections/transparency/containers/HorizontalBars.js
@@ -8,7 +8,8 @@ const Horizontalbars = () => (
             {`
             .parity-section {
                 display: flex;
-                justify-content: center;                width: 100%;
+                justify-content: center;                
+                width: 100%;
             }
            `}
             </style>

--- a/sections/transparency/containers/VerticalBars.js
+++ b/sections/transparency/containers/VerticalBars.js
@@ -8,8 +8,12 @@ const VerticalBars = () => {
     return(
         <section className="verticalBar-section">
             <div className="title"><h1>{t('transparency.barGraphic.title')}</h1></div>
+            <div className="details-graphic">
             <Details subtitle={t('transparency.barGraphic.income.subtitle')}/>
+            </div>
+            <div className="detailsOutcome-graphic">
             <DetailOutcome subtitle={t('transparency.barGraphic.outcome.subtitle')}/>
+            </div>
                 <div className='btn-container'>
             <a  href={t('transparency.barGraphic.urldownload')} target="_blank">
         
@@ -38,6 +42,7 @@ const VerticalBars = () => {
                 justify-content: center;
                 width: 100%;
             }
+           
            `}
             </style>
         </section>

--- a/sections/transparency/containers/VerticalBars.js
+++ b/sections/transparency/containers/VerticalBars.js
@@ -8,16 +8,16 @@ const VerticalBars = () => {
     return(
         <section className="verticalBar-section">
             <div className="title"><h1>{t('transparency.barGraphic.title')}</h1></div>
-            <div className="details-graphic">
+            <div className="graphics-container">
             <Details subtitle={t('transparency.barGraphic.income.subtitle')}/>
-            </div>
-            <div className="detailsOutcome-graphic">
+            
+           
             <DetailOutcome subtitle={t('transparency.barGraphic.outcome.subtitle')}/>
             </div>
                 <div className='btn-container'>
             <a  href={t('transparency.barGraphic.urldownload')} target="_blank">
         
-                    <button className='btn'>
+                    <button className='btn balance-button'>
                     <span className='action-text'>{t('transparency.barGraphic.btn-text')}</span>
                     </button>
             </a>
@@ -31,6 +31,11 @@ const VerticalBars = () => {
                  width: 100%;
                  flex-flow: row wrap;
             }
+            .graphics-container {
+                display: flex;
+                flex-flow: row wrap;
+                justify-content: center; 
+            }
             .title {
                 width: 100%;
                 margin: 20px;
@@ -42,6 +47,20 @@ const VerticalBars = () => {
                 justify-content: center;
                 width: 100%;
             }
+            .balance-button {
+                width: 24.5rem;
+            }
+
+            @media (min-width: 341px) and (max-width: 1500x) {
+                .graphics-container {
+                    display: flex;
+                    flex-flow: row nowrap;
+                    justify-content: center; 
+                }
+
+            }
+            
+
            
            `}
             </style>

--- a/translations/en.json
+++ b/translations/en.json
@@ -76,7 +76,7 @@
           "subtitle": "Who funds us? How we spend?",
           "text": "Here is all accounting information summarized and documentary support.",
           "icon": "/static/assets/icons/transparency.svg",
-          "callToAction": "Download PDF",
+          "callToAction": "Transparency",
           "href": "https://drive.google.com/file/d/18-rWaYPOXxVCjzH4zNySzl9c5HtFhr4x/view",
           "classbtn": "btn last-btn"
 
@@ -395,7 +395,7 @@
       "outcome": {
         "subtitle": "Outcome by fiscal year object"
       },
-      "btn-text": "See more",
+      "btn-text": "Full balance sheet",
       "urldownload": "https://drive.google.com/drive/folders/18FqJdWg7Ucj6sey126T_SQPUQv0hZFyy"
     
     },
@@ -403,8 +403,8 @@
       "subtitle": "Team's parity"
     },
     "balanceSheet": {
-      "text": "Balance Sheet",
-      "btn-text": "2018's balance",
+      "text": "2018 Memoirs",
+      "btn-text": "Ver informe",
       "urldownload": "https://drive.google.com/file/d/1dOuw_imRgG0dLA539Zoi6OIlRMCXInnd/view"
     }
   },
@@ -466,6 +466,10 @@
       {
         "href": "ebooks",
         "title": "E-books"
+      },
+      {
+        "href": "videos",
+        "title": "Audiovisual Material"
       },
       {
         "href": "media",

--- a/translations/es.json
+++ b/translations/es.json
@@ -78,7 +78,7 @@
           "subtitle": "¿Quién nos financia? ¿Cómo gastamos?",
           "text": "Aquí todos nuestros balances financieros.",
           "icon": "/static/assets/icons/transparency.svg",
-          "callToAction": "Ver Balances",
+          "callToAction": "Transparencia",
           "href": "/transparency",
           "classbtn": "'btn last-btn'"
         }
@@ -395,15 +395,15 @@
       "outcome": {
         "subtitle": "Egreso por objeto del año fiscal"
       },
-      "btn-text": "Ver más",
+      "btn-text": "Balances completos",
       "urldownload": "https://drive.google.com/drive/folders/18FqJdWg7Ucj6sey126T_SQPUQv0hZFyy"
     },
     "horizontalGraphic": {
       "subtitle": "Paridad del Equipo"
     },
     "balanceSheet": {
-      "text": "Ver informe de gestión 2018",
-      "btn-text": "Balance 2018",
+      "text": "Memorias 2018",
+      "btn-text": "Ver más",
       "urldownload": "https://drive.google.com/file/d/1dOuw_imRgG0dLA539Zoi6OIlRMCXInnd/view"
     
     }
@@ -466,6 +466,10 @@
       {
         "href": "ebooks",
         "title": "E-books"
+      },
+      {
+        "href": "videos",
+        "title": "Material Audiovisual"
       },
       {
         "href": "media",


### PR DESCRIPTION
# Parche 3.0.1

## Cambios de diseño: 

- Se agregaron opciones reponsive a la página `/transparency` en los gráficos. 
- Correción en los gráficos doughnut, donde a medida que disminuía la pantalla, los gráficos se distorsionaban ocupando toda la pantalla. 
- Cambios generales a los títulos y textos en los botones en `/transparency`
- Se añadió la font-family general al gráfico de paridad. 
- El video cabacera, en material audiovisual, se cambió por "Webinario". 

## Cambios de estructura: 

- La sección "Material audiovisual" ya es linkeable directamente, agregándose al modal, navbar y footer. 
- Los gráficos poseen otra visualización de datos, aparecen con porcentaje y valor monetario según corresponda. 
