### PR TITLE
fix typo in spanish lang file

### DIFF
--- a/translations/es.json
+++ b/translations/es.json
@@ -181,7 +181,7 @@
       "title": "¿Quiénes somos?",
       "subtitle": ["Somos una organización de la sociedad conformada por personas activistas,",
        "programadoras y científicas sociales que desde el hacer", 
-       "buscamos abrir las instituciones públicas y los procesos de toma de decisión.",
+       "buscamos abrir las instituciones públicas y los procesos de toma de decisión.",
        "Buscamos recuperar la política."],
       "team": [
         {


### PR DESCRIPTION
Hay un error ortográfico en la home: https://democraciaenred.org/ sobre la sección _¿Quiénes somos?_. Dice:
```
[..] buscamos abrir las instituciones públicas y [..]
```